### PR TITLE
[3주차] 과제

### DIFF
--- a/src/main/java/org/sopt/seminar2/diary/api/DiaryController.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/DiaryController.java
@@ -7,10 +7,10 @@ import org.sopt.seminar2.diary.api.dto.request.DiaryCreateRequest;
 import org.sopt.seminar2.diary.api.dto.request.DiaryUpdateRequest;
 import org.sopt.seminar2.diary.api.dto.response.DiaryDetailResponse;
 import org.sopt.seminar2.diary.api.dto.response.DiaryListResponse;
+import org.sopt.seminar2.diary.common.dto.SuccessResponse;
 import org.sopt.seminar2.diary.service.DiaryService;
 
 import org.springframework.http.ResponseEntity;
-
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -21,6 +21,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.sopt.seminar2.diary.common.code.SuccessCode.SUCESS_CREATE_DIARY;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -29,15 +31,16 @@ public class DiaryController {
     private final DiaryService diaryService;
 
     @PostMapping("/diary")
-    public ResponseEntity<Void> postDiary(
+    public ResponseEntity<SuccessResponse> postDiary(
             @Valid @RequestBody DiaryCreateRequest diaryCreateRequest,
             @RequestHeader("username") String username,
             @RequestHeader("password") String password
     ) {
         diaryService.postDiary(diaryCreateRequest, username, password);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(SuccessResponse.of(SUCESS_CREATE_DIARY));
     }
 
+    // 일기 상세 조회
     @GetMapping("/diary/{diaryId}")
     public ResponseEntity<DiaryDetailResponse> getDiary(
             @PathVariable long diaryId
@@ -54,18 +57,22 @@ public class DiaryController {
 
     @DeleteMapping("/diary/{diaryId}")
     public ResponseEntity<Void> deleteDiary(
-            @PathVariable long diaryId
+            @PathVariable long diaryId,
+            @RequestHeader("username") String username,
+            @RequestHeader("password") String password
     ) {
-        diaryService.deleteDiary(diaryId);
+        diaryService.deleteDiary(diaryId, username, password);
         return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/diary/{diaryId}")
     public ResponseEntity<Void> updateDiary(
             @PathVariable long diaryId,
+            @RequestHeader("username") String username,
+            @RequestHeader("password") String password,
             @RequestBody DiaryUpdateRequest diaryUpdateRequest
     ) {
-        diaryService.updateDiary(diaryId, diaryUpdateRequest);
+        diaryService.updateDiary(diaryId, diaryUpdateRequest, username, password);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/org/sopt/seminar2/diary/api/DiaryController.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/DiaryController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,9 +30,11 @@ public class DiaryController {
 
     @PostMapping("/diary")
     public ResponseEntity<Void> postDiary(
-            @Valid @RequestBody DiaryCreateRequest diaryCreateRequest
+            @Valid @RequestBody DiaryCreateRequest diaryCreateRequest,
+            @RequestHeader("username") String username,
+            @RequestHeader("password") String password
     ) {
-        diaryService.postDiary(diaryCreateRequest);
+        diaryService.postDiary(diaryCreateRequest, username, password);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/org/sopt/seminar2/diary/api/annotation/CheckUserAuth.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/annotation/CheckUserAuth.java
@@ -1,0 +1,12 @@
+package org.sopt.seminar2.diary.api.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface CheckUserAuth {
+}

--- a/src/main/java/org/sopt/seminar2/diary/api/controller/DiaryController.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/controller/DiaryController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.sopt.seminar2.diary.common.code.SuccessCode.SUCCESS_CREATE_DIARY;
@@ -66,8 +67,10 @@ public class DiaryController {
 
     // 메인 홈
     @GetMapping("/diary")
-    public ResponseEntity<DiaryListResponse> getDiaryList() {
-        DiaryListResponse diaryListResponse = diaryService.getDiaryList();
+    public ResponseEntity<DiaryListResponse> getDiaryList(
+            @RequestParam(required = false) String category
+    ) {
+        DiaryListResponse diaryListResponse = diaryService.getDiaryList(Category.findCategory(category));
         return ResponseEntity.ok().body(diaryListResponse);
     }
 

--- a/src/main/java/org/sopt/seminar2/diary/api/controller/DiaryController.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/controller/DiaryController.java
@@ -74,6 +74,17 @@ public class DiaryController {
         return ResponseEntity.ok().body(diaryListResponse);
     }
 
+    // 내 일기 모아보기
+    @GetMapping("/mypage/diary")
+    public ResponseEntity<DiaryListResponse> getMyDairyList(
+            @RequestHeader(USERNAME_HEADER) String username,
+            @RequestHeader(PASSWORD_HEADER) String password,
+            @RequestParam(required = false) String category
+    ) {
+        DiaryListResponse diaryListResponse = diaryService.getMyDiaryList(Category.findCategory(category), username, password);
+        return ResponseEntity.ok().body(diaryListResponse);
+    }
+
     // 일기 삭제
     @DeleteMapping("/diary/{diaryId}")
     @CheckUserAuth

--- a/src/main/java/org/sopt/seminar2/diary/api/controller/DiaryController.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/controller/DiaryController.java
@@ -1,8 +1,9 @@
-package org.sopt.seminar2.diary.api;
+package org.sopt.seminar2.diary.api.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+import org.sopt.seminar2.diary.api.annotation.CheckUserAuth;
 import org.sopt.seminar2.diary.api.dto.request.DiaryCreateRequest;
 import org.sopt.seminar2.diary.api.dto.request.DiaryUpdateRequest;
 import org.sopt.seminar2.diary.api.dto.response.DiaryDetailResponse;
@@ -21,34 +22,42 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static org.sopt.seminar2.diary.common.code.SuccessCode.SUCESS_CREATE_DIARY;
+import static org.sopt.seminar2.diary.common.code.SuccessCode.SUCCESS_CREATE_DIARY;
+import static org.sopt.seminar2.diary.common.code.SuccessCode.SUCCESS_GET_DIARY_DETAIL;
+import static org.sopt.seminar2.diary.common.code.SuccessCode.SUCCESS_DELETE_DIARY;
+import static org.sopt.seminar2.diary.common.code.SuccessCode.SUCCESS_UPDATE_DIARY;
+
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class DiaryController {
 
+    private final String USERNAME_HEADER = "username";
+    private final String PASSWORD_HEADER = "password";
+
     private final DiaryService diaryService;
 
     @PostMapping("/diary")
     public ResponseEntity<SuccessResponse> postDiary(
             @Valid @RequestBody DiaryCreateRequest diaryCreateRequest,
-            @RequestHeader("username") String username,
-            @RequestHeader("password") String password
+            @RequestHeader(USERNAME_HEADER) String username,
+            @RequestHeader(PASSWORD_HEADER) String password
     ) {
         diaryService.postDiary(diaryCreateRequest, username, password);
-        return ResponseEntity.ok(SuccessResponse.of(SUCESS_CREATE_DIARY));
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_CREATE_DIARY));
     }
 
     // 일기 상세 조회
     @GetMapping("/diary/{diaryId}")
-    public ResponseEntity<DiaryDetailResponse> getDiary(
+    public ResponseEntity<SuccessResponse<DiaryDetailResponse>> getDiary(
             @PathVariable long diaryId
     ) {
         DiaryDetailResponse diaryDetailResponse = diaryService.getDiary(diaryId);
-        return ResponseEntity.ok().body(diaryDetailResponse);
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_GET_DIARY_DETAIL, diaryDetailResponse));
     }
 
+    // 메인 홈
     @GetMapping("/diary")
     public ResponseEntity<DiaryListResponse> getDiaryList() {
         DiaryListResponse diaryListResponse = diaryService.getDiaryList();
@@ -56,24 +65,26 @@ public class DiaryController {
     }
 
     @DeleteMapping("/diary/{diaryId}")
-    public ResponseEntity<Void> deleteDiary(
+    @CheckUserAuth
+    public ResponseEntity<SuccessResponse> deleteDiary(
             @PathVariable long diaryId,
-            @RequestHeader("username") String username,
-            @RequestHeader("password") String password
+            @RequestHeader(USERNAME_HEADER) String username,
+            @RequestHeader(PASSWORD_HEADER) String password
     ) {
         diaryService.deleteDiary(diaryId, username, password);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_DELETE_DIARY));
     }
 
     @PatchMapping("/diary/{diaryId}")
-    public ResponseEntity<Void> updateDiary(
+    @CheckUserAuth
+    public ResponseEntity<SuccessResponse> updateDiary(
             @PathVariable long diaryId,
-            @RequestHeader("username") String username,
-            @RequestHeader("password") String password,
+            @RequestHeader(USERNAME_HEADER) String username,
+            @RequestHeader(PASSWORD_HEADER) String password,
             @RequestBody DiaryUpdateRequest diaryUpdateRequest
     ) {
         diaryService.updateDiary(diaryId, diaryUpdateRequest, username, password);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(SuccessResponse.of(SUCCESS_UPDATE_DIARY));
     }
 
 }

--- a/src/main/java/org/sopt/seminar2/diary/api/controller/DiaryController.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/controller/DiaryController.java
@@ -9,6 +9,7 @@ import org.sopt.seminar2.diary.api.dto.request.DiaryUpdateRequest;
 import org.sopt.seminar2.diary.api.dto.response.DiaryDetailResponse;
 import org.sopt.seminar2.diary.api.dto.response.DiaryListResponse;
 import org.sopt.seminar2.diary.common.dto.SuccessResponse;
+import org.sopt.seminar2.diary.domain.enums.Category;
 import org.sopt.seminar2.diary.service.DiaryService;
 
 import org.springframework.http.ResponseEntity;
@@ -44,7 +45,13 @@ public class DiaryController {
             @RequestHeader(USERNAME_HEADER) String username,
             @RequestHeader(PASSWORD_HEADER) String password
     ) {
-        diaryService.postDiary(diaryCreateRequest, username, password);
+        diaryService.postDiary(
+                diaryCreateRequest.title(),
+                diaryCreateRequest.content(),
+                Category.findCategory(diaryCreateRequest.category()),
+                username,
+                password
+        );
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_CREATE_DIARY));
     }
 
@@ -64,6 +71,7 @@ public class DiaryController {
         return ResponseEntity.ok().body(diaryListResponse);
     }
 
+    // 일기 삭제
     @DeleteMapping("/diary/{diaryId}")
     @CheckUserAuth
     public ResponseEntity<SuccessResponse> deleteDiary(
@@ -75,6 +83,7 @@ public class DiaryController {
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_DELETE_DIARY));
     }
 
+    // 일기 수정
     @PatchMapping("/diary/{diaryId}")
     @CheckUserAuth
     public ResponseEntity<SuccessResponse> updateDiary(
@@ -83,7 +92,7 @@ public class DiaryController {
             @RequestHeader(PASSWORD_HEADER) String password,
             @RequestBody DiaryUpdateRequest diaryUpdateRequest
     ) {
-        diaryService.updateDiary(diaryId, diaryUpdateRequest, username, password);
+        diaryService.updateDiary(diaryId, diaryUpdateRequest.content(), username, password);
         return ResponseEntity.ok(SuccessResponse.of(SUCCESS_UPDATE_DIARY));
     }
 

--- a/src/main/java/org/sopt/seminar2/diary/api/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/dto/request/DiaryCreateRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Size;
 public record DiaryCreateRequest(
 
         @Size(min = 1, max = 10, message = "제목은 10자 이하여야 합니다.")
-
         String title,
 
         @Size(min = 1, max = 30, message = "본문은 30자 이하여야 합니다.")

--- a/src/main/java/org/sopt/seminar2/diary/api/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/dto/request/DiaryCreateRequest.java
@@ -8,6 +8,8 @@ public record DiaryCreateRequest(
         String title,
 
         @Size(min = 1, max = 30, message = "본문은 30자 이하여야 합니다.")
-        String content
+        String content,
+
+        String category
 ) {
 }

--- a/src/main/java/org/sopt/seminar2/diary/api/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/dto/request/DiaryCreateRequest.java
@@ -3,9 +3,12 @@ package org.sopt.seminar2.diary.api.dto.request;
 import jakarta.validation.constraints.Size;
 
 public record DiaryCreateRequest(
+
+        @Size(min = 1, max = 10, message = "제목은 10자 이하여야 합니다.")
+
         String title,
 
-        @Size(max = 30, message = "글자수는 30자 이하여야 합니다.")
+        @Size(min = 1, max = 30, message = "본문은 30자 이하여야 합니다.")
         String content
 ) {
 }

--- a/src/main/java/org/sopt/seminar2/diary/api/interceptor/CheckUserAuthInterceptor.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/interceptor/CheckUserAuthInterceptor.java
@@ -1,0 +1,77 @@
+package org.sopt.seminar2.diary.api.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
+
+import org.sopt.seminar2.diary.api.annotation.CheckUserAuth;
+import org.sopt.seminar2.diary.common.exception.DiaryException;
+import org.sopt.seminar2.diary.common.exception.UserException;
+import org.sopt.seminar2.diary.domain.Diary;
+import org.sopt.seminar2.diary.domain.User;
+import org.sopt.seminar2.diary.domain.repository.DiaryRepository;
+import org.sopt.seminar2.diary.domain.repository.UserRepository;
+
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.Map;
+
+import static org.sopt.seminar2.diary.common.code.FailureCode.*;
+
+
+@Component
+@RequiredArgsConstructor
+public class CheckUserAuthInterceptor implements HandlerInterceptor {
+
+    private final String USERNAME_HEADER = "username";
+    private final String PASSWORD_HEADER = "password";
+
+    private final DiaryRepository diaryRepository;
+    private final UserRepository userRepository;
+    @Override
+    @Transactional
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // Handler가 메소드인 경우에만 진행
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod handlerMethod = (HandlerMethod) handler;
+
+            // 핸들러 메서드에 @CheckUserAuth 어노테이션이 있는지 확인
+            if (handlerMethod.getMethod().isAnnotationPresent(CheckUserAuth.class)) {
+                String username = request.getHeader(USERNAME_HEADER);
+                String password = request.getHeader(PASSWORD_HEADER);
+
+                Map<String, String> pathVariables = (Map<String, String>) request
+                        .getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+
+                Long diaryId = Long.valueOf(pathVariables.get("diaryId"));
+                
+                User loginUser = getLoginUser(username);
+                Diary diary = getDiary(diaryId);
+
+                boolean isOwner = loginUser.equals(diary.getUser());
+
+                if (!isOwner) {
+                    throw new UserException(NO_PERMISSON_FOR_DAIRY);
+                }
+
+            }
+        }
+        return true;
+    }
+
+    private User getLoginUser(String username) {
+       return userRepository.findByUsername(username)
+               .orElseThrow(() -> new UserException(NOT_EXISTS_USER));
+    }
+
+    private Diary getDiary(long diaryId) {
+        return diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new DiaryException(NOT_EXISTS_DIARY_WITH_ID));
+    }
+}

--- a/src/main/java/org/sopt/seminar2/diary/api/interceptor/CheckUserAuthInterceptor.java
+++ b/src/main/java/org/sopt/seminar2/diary/api/interceptor/CheckUserAuthInterceptor.java
@@ -34,9 +34,11 @@ public class CheckUserAuthInterceptor implements HandlerInterceptor {
 
     private final DiaryRepository diaryRepository;
     private final UserRepository userRepository;
+
     @Override
     @Transactional
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
         // Handler가 메소드인 경우에만 진행
         if (handler instanceof HandlerMethod) {
             HandlerMethod handlerMethod = (HandlerMethod) handler;
@@ -59,7 +61,6 @@ public class CheckUserAuthInterceptor implements HandlerInterceptor {
                 if (!isOwner) {
                     throw new UserException(NO_PERMISSON_FOR_DAIRY);
                 }
-
             }
         }
         return true;

--- a/src/main/java/org/sopt/seminar2/diary/common/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package org.sopt.seminar2.diary.common;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.sopt.seminar2.diary.common.code.FailureCode;
+import org.sopt.seminar2.diary.common.dto.ErrorResponse;
+
+import org.sopt.seminar2.diary.common.exception.ApiException;
+import org.sopt.seminar2.diary.common.exception.DiaryException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DiaryException.class)
+    public ResponseEntity<ErrorResponse> handleDiaryException(ApiException e) {
+        log.error("[DairyException] 발생 : {}" , e.getMessage());
+
+        FailureCode failureCode = e.getFailureCode();
+        return ResponseEntity.status(failureCode.getHttpStatus())
+                .body(ErrorResponse.of(
+                        failureCode.getHttpStatus().value(),
+                        failureCode.getMessage()
+                ));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("[MethodArgumentNotValidException] 발생 : {}", e.getMessage());
+
+        FailureCode failureCode = FailureCode.INVALID_VALUE;
+        return ResponseEntity.status(failureCode.getHttpStatus())
+                .body(ErrorResponse.of(
+                        failureCode.getHttpStatus().value(),
+                        failureCode.getMessage(),
+                        e.getBindingResult()
+                ));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleValidationFailure(MissingServletRequestParameterException e) {
+        log.error("[MissingParameterException] 발생 : {}", e.getMessage());
+
+        FailureCode failureCode = FailureCode.MISSING_PARAMETER;
+        return ResponseEntity.status(failureCode.getHttpStatus())
+                .body(ErrorResponse.of(
+                        failureCode.getHttpStatus().value(),
+                        failureCode.getMessage()
+                ));
+    }
+}

--- a/src/main/java/org/sopt/seminar2/diary/common/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/GlobalExceptionHandler.java
@@ -4,9 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.sopt.seminar2.diary.common.code.FailureCode;
 import org.sopt.seminar2.diary.common.dto.ErrorResponse;
-
 import org.sopt.seminar2.diary.common.exception.ApiException;
-import org.sopt.seminar2.diary.common.exception.DiaryException;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -19,7 +18,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<ErrorResponse> handleDiaryException(ApiException e) {
-        log.error("[DairyException] 발생 : {}" , e.getMessage());
+        log.error(e.getMessage());
 
         FailureCode failureCode = e.getFailureCode();
         return ResponseEntity.status(failureCode.getHttpStatus())

--- a/src/main/java/org/sopt/seminar2/diary/common/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/GlobalExceptionHandler.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(DiaryException.class)
+    @ExceptionHandler(ApiException.class)
     public ResponseEntity<ErrorResponse> handleDiaryException(ApiException e) {
         log.error("[DairyException] 발생 : {}" , e.getMessage());
 

--- a/src/main/java/org/sopt/seminar2/diary/common/code/FailureCode.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/code/FailureCode.java
@@ -13,7 +13,7 @@ public enum FailureCode {
     // User
     NOT_EXISTS_USER(HttpStatus.NOT_FOUND, "해당 이름을 가진 유저가 존재하지 않습니다."),
     NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-
+    NO_PERMISSON_FOR_DAIRY(HttpStatus.FORBIDDEN, "해당 일기에 대한 권한이 없습니다."),
 
     // Diary
     NOT_EXISTS_DIARY_WITH_ID(HttpStatus.NOT_FOUND, "id에 해당하는 일기가 없습니다."),

--- a/src/main/java/org/sopt/seminar2/diary/common/code/FailureCode.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/code/FailureCode.java
@@ -1,0 +1,23 @@
+package org.sopt.seminar2.diary.common.code;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum FailureCode {
+
+    INVALID_VALUE(HttpStatus.BAD_REQUEST, "잘못된 값입니다."),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 없습니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/org/sopt/seminar2/diary/common/code/FailureCode.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/code/FailureCode.java
@@ -7,7 +7,12 @@ import org.springframework.http.HttpStatus;
 public enum FailureCode {
 
     INVALID_VALUE(HttpStatus.BAD_REQUEST, "잘못된 값입니다."),
-    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 없습니다.");
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 없습니다."),
+    NOT_EXISTS_CATEGORY(HttpStatus.BAD_REQUEST, "잘못된 카테고리 값입니다."),
+
+    // User
+    NOT_EXISTS_USER(HttpStatus.NOT_FOUND, "해당 이름을 가진 유저가 존재하지 않습니다."),
+    NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/sopt/seminar2/diary/common/code/FailureCode.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/code/FailureCode.java
@@ -12,7 +12,12 @@ public enum FailureCode {
 
     // User
     NOT_EXISTS_USER(HttpStatus.NOT_FOUND, "해당 이름을 가진 유저가 존재하지 않습니다."),
-    NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+    NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+
+
+    // Diary
+    NOT_EXISTS_DIARY_WITH_ID(HttpStatus.NOT_FOUND, "id에 해당하는 일기가 없습니다."),
+    NOT_EXISTS_DIARY_WITH_ID_AND_USER(HttpStatus.NOT_FOUND, "유저와 id에 해당하는 일기가 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/sopt/seminar2/diary/common/code/SuccessCode.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/code/SuccessCode.java
@@ -1,0 +1,25 @@
+package org.sopt.seminar2.diary.common.code;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SuccessCode {
+
+    SUCESS_CREATE_DIARY(HttpStatus.CREATED, "일기 작성에 성공했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/seminar2/diary/common/code/SuccessCode.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/code/SuccessCode.java
@@ -10,7 +10,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SuccessCode {
 
-    SUCESS_CREATE_DIARY(HttpStatus.CREATED, "일기 작성에 성공했습니다.");
+    SUCCESS_CREATE_DIARY(HttpStatus.CREATED, "일기 작성에 성공했습니다."),
+    SUCCESS_UPDATE_DIARY(HttpStatus.OK, "일기 수정에 성공했습니다."),
+    SUCCESS_DELETE_DIARY(HttpStatus.OK, "일기 삭제에 성공했습니다."),
+    SUCCESS_GET_DIARY_DETAIL(HttpStatus.OK, "일기 상세 조회에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/sopt/seminar2/diary/common/dto/ErrorResponse.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/dto/ErrorResponse.java
@@ -1,0 +1,49 @@
+package org.sopt.seminar2.diary.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Builder
+public record ErrorResponse(
+        int status,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        List<ValidationError> errors
+) {
+    public static ErrorResponse of(int status, String message){
+        return ErrorResponse.builder()
+                .status(status)
+                .message(message)
+                .build();
+    }
+
+    public static ErrorResponse of(int status, String message, BindingResult bindingResult){
+        return ErrorResponse.builder()
+                .status(status)
+                .message(message)
+                .errors(ValidationError.of(bindingResult))
+                .build();
+    }
+
+    @Getter
+    public static class ValidationError {
+        private final String field;
+        private final String message;
+
+        private ValidationError(FieldError fieldError){
+            this.field = fieldError.getField();
+            this.message = fieldError.getDefaultMessage();
+        }
+
+        public static List<ValidationError> of(final BindingResult bindingResult){
+            return bindingResult.getFieldErrors().stream()
+                    .map(ValidationError::new)
+                    .toList();
+        }
+    }
+}

--- a/src/main/java/org/sopt/seminar2/diary/common/dto/SuccessResponse.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/dto/SuccessResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.seminar2.diary.common.dto;
+
+import org.sopt.seminar2.diary.common.code.SuccessCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"status", "message", "result"})
+public record SuccessResponse<T>(
+        int status,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        T result
+) {
+    public static <T> SuccessResponse of(SuccessCode successCode){
+        return new SuccessResponse(successCode.getHttpStatus().value(), successCode.getMessage(), null);
+    }
+
+    public static <T> SuccessResponse of(SuccessCode successCode, T result){
+        return new SuccessResponse(successCode.getHttpStatus().value(), successCode.getMessage(), result);
+    }
+}

--- a/src/main/java/org/sopt/seminar2/diary/common/exception/ApiException.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/exception/ApiException.java
@@ -1,0 +1,23 @@
+package org.sopt.seminar2.diary.common.exception;
+
+import org.sopt.seminar2.diary.common.code.FailureCode;
+
+public class ApiException extends RuntimeException {
+
+    private final FailureCode failureCode;
+    private final String errorMessage;
+
+    public FailureCode getFailureCode() {
+        return failureCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public ApiException(FailureCode failureCode, String errorMessage) {
+        super(errorMessage + ": " + failureCode.getMessage());
+        this.failureCode = failureCode;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/org/sopt/seminar2/diary/common/exception/DiaryException.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/exception/DiaryException.java
@@ -1,0 +1,18 @@
+package org.sopt.seminar2.diary.common.exception;
+
+import org.sopt.seminar2.diary.common.code.FailureCode;
+
+public class DiaryException extends ApiException {
+
+    private final FailureCode failureCode;
+
+    public FailureCode getFailureCode() {
+        return failureCode;
+    }
+
+    public DiaryException(FailureCode failureCode) {
+        super(failureCode, "[DiaryException]");
+        this.failureCode = failureCode;
+    }
+
+}

--- a/src/main/java/org/sopt/seminar2/diary/common/exception/UserException.java
+++ b/src/main/java/org/sopt/seminar2/diary/common/exception/UserException.java
@@ -1,0 +1,17 @@
+package org.sopt.seminar2.diary.common.exception;
+
+import org.sopt.seminar2.diary.common.code.FailureCode;
+
+public class UserException extends ApiException {
+
+    private final FailureCode failureCode;
+
+    public FailureCode getFailureCode() {
+        return failureCode;
+    }
+
+    public UserException(FailureCode failureCode) {
+        super(failureCode, "[UserException]");
+        this.failureCode = failureCode;
+    }
+}

--- a/src/main/java/org/sopt/seminar2/diary/domain/Diary.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/Diary.java
@@ -1,5 +1,7 @@
 package org.sopt.seminar2.diary.domain;
 
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import org.sopt.seminar2.diary.domain.enums.Category;
 
 import jakarta.persistence.Column;
@@ -16,6 +18,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
@@ -26,6 +29,10 @@ public class Diary {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Column(unique = true, nullable = false)
     private String title;
@@ -39,14 +46,16 @@ public class Diary {
     private LocalDateTime createdAt;
 
     @Builder
-    private Diary(final String title, final String content) {
+    private Diary(final User user, final String title, final String content) {
+        this.user = user;
         this.title = title;
         this.content = content;
         this.createdAt = LocalDateTime.now();
     }
 
-    public static Diary create(final String title, final String content) {
+    public static Diary create(final User user, final String title, final String content) {
         return Diary.builder()
+                .user(user)
                 .title(title)
                 .content(content)
                 .build();

--- a/src/main/java/org/sopt/seminar2/diary/domain/Diary.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/Diary.java
@@ -23,6 +23,7 @@ public class Diary {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String title;
 
     private String content;

--- a/src/main/java/org/sopt/seminar2/diary/domain/Diary.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/Diary.java
@@ -1,7 +1,11 @@
 package org.sopt.seminar2.diary.domain;
 
+import org.sopt.seminar2.diary.domain.enums.Category;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,10 +27,14 @@ public class Diary {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private String title;
 
+    @Column(nullable = false)
     private String content;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
 
     private LocalDateTime createdAt;
 

--- a/src/main/java/org/sopt/seminar2/diary/domain/Diary.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/Diary.java
@@ -46,18 +46,30 @@ public class Diary {
     private LocalDateTime createdAt;
 
     @Builder
-    private Diary(final User user, final String title, final String content) {
+    private Diary(
+            final User user,
+            final String title,
+            final String content,
+            final Category category
+    ) {
         this.user = user;
         this.title = title;
         this.content = content;
         this.createdAt = LocalDateTime.now();
+        this.category = category;
     }
 
-    public static Diary create(final User user, final String title, final String content) {
+    public static Diary create(
+            final User user,
+            final String title,
+            final String content,
+            final Category category
+    ) {
         return Diary.builder()
                 .user(user)
                 .title(title)
                 .content(content)
+                .category(category)
                 .build();
     }
 

--- a/src/main/java/org/sopt/seminar2/diary/domain/User.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/User.java
@@ -26,4 +26,15 @@ public class User {
 
     private String nickname;
 
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
 }

--- a/src/main/java/org/sopt/seminar2/diary/domain/User.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/User.java
@@ -1,0 +1,29 @@
+package org.sopt.seminar2.diary.domain;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "Users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String password;
+
+    private String nickname;
+
+}

--- a/src/main/java/org/sopt/seminar2/diary/domain/enums/Category.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/enums/Category.java
@@ -1,0 +1,20 @@
+package org.sopt.seminar2.diary.domain.enums;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+public enum Category {
+
+    FOOD("food"),
+    SCHOOL("school"),
+    MOVIE("movie"),
+    WORK_OUT("workout");
+
+    private final String name;
+
+    public static Category findCategory(String name) {
+        Arrays.stream(Category.values()).filter(category -> category.name.equals(name)).findAny().orElseThrow()
+    }
+}

--- a/src/main/java/org/sopt/seminar2/diary/domain/enums/Category.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/enums/Category.java
@@ -18,6 +18,9 @@ public enum Category {
     private final String name;
 
     public static Category findCategory(String name) {
+        if (name == null) {
+            return null;
+        }
         return Arrays.stream(Category.values()).filter(category -> category.name.equals(name)).findAny()
                 .orElseThrow(() -> new DiaryException(NOT_EXISTS_CATEGORY));
     }

--- a/src/main/java/org/sopt/seminar2/diary/domain/enums/Category.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/enums/Category.java
@@ -1,8 +1,11 @@
 package org.sopt.seminar2.diary.domain.enums;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.seminar2.diary.common.exception.DiaryException;
 
 import java.util.Arrays;
+
+import static org.sopt.seminar2.diary.common.code.FailureCode.NOT_EXISTS_CATEGORY;
 
 @RequiredArgsConstructor
 public enum Category {
@@ -15,6 +18,7 @@ public enum Category {
     private final String name;
 
     public static Category findCategory(String name) {
-        Arrays.stream(Category.values()).filter(category -> category.name.equals(name)).findAny().orElseThrow()
+        return Arrays.stream(Category.values()).filter(category -> category.name.equals(name)).findAny()
+                .orElseThrow(() -> new DiaryException(NOT_EXISTS_CATEGORY));
     }
 }

--- a/src/main/java/org/sopt/seminar2/diary/domain/repository/DiaryRepository.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/repository/DiaryRepository.java
@@ -3,14 +3,20 @@ package org.sopt.seminar2.diary.domain.repository;
 import org.sopt.seminar2.diary.domain.Diary;
 import org.sopt.seminar2.diary.domain.User;
 
+import org.sopt.seminar2.diary.domain.enums.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
-    List<Diary> findAllByOrderByCreatedAtDesc();
+    @Query("SELECT d FROM Diary d " +
+            "WHERE (:category IS NULL OR d.category = :category) " +
+            "ORDER BY d.createdAt DESC")
+    List<Diary> findTop10ByCategory(@Param("category") Category category);
 
     Optional<Diary> findByIdAndUser(Long id, User user);
 }

--- a/src/main/java/org/sopt/seminar2/diary/domain/repository/DiaryRepository.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/repository/DiaryRepository.java
@@ -1,12 +1,16 @@
 package org.sopt.seminar2.diary.domain.repository;
 
 import org.sopt.seminar2.diary.domain.Diary;
+import org.sopt.seminar2.diary.domain.User;
+
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     List<Diary> findAllByOrderByCreatedAtDesc();
+
+    Optional<Diary> findByIdAndUser(Long id, User user);
 }

--- a/src/main/java/org/sopt/seminar2/diary/domain/repository/DiaryRepository.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/repository/DiaryRepository.java
@@ -18,5 +18,10 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
             "ORDER BY d.createdAt DESC")
     List<Diary> findTop10ByCategory(@Param("category") Category category);
 
+    @Query("SELECT d FROM Diary d " +
+            "WHERE (:category IS NULL OR d.category = :category) AND (d.user = :user)" +
+            "ORDER BY d.createdAt DESC")
+    List<Diary> findTop10ByCategoryAndUser(@Param("category") Category category, @Param("user") User user);
+
     Optional<Diary> findByIdAndUser(Long id, User user);
 }

--- a/src/main/java/org/sopt/seminar2/diary/domain/repository/UserRepository.java
+++ b/src/main/java/org/sopt/seminar2/diary/domain/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.seminar2.diary.domain.repository;
+
+import org.sopt.seminar2.diary.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+}

--- a/src/main/java/org/sopt/seminar2/diary/global/config/WebConfig.java
+++ b/src/main/java/org/sopt/seminar2/diary/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package org.sopt.seminar2.diary.global.config;
+
+import lombok.RequiredArgsConstructor;
+
+import org.sopt.seminar2.diary.api.interceptor.CheckUserAuthInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CheckUserAuthInterceptor checkUserAuthInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(checkUserAuthInterceptor);
+    }
+}

--- a/src/main/java/org/sopt/seminar2/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/seminar2/diary/service/DiaryService.java
@@ -51,12 +51,12 @@ public class DiaryService {
     }
 
     public DiaryListResponse getDiaryList(final Category category) {
-        List<Diary> diaries = diaryRepository.findTop10ByCategory(category);
-        List<DiaryListResponse.DiaryResponse> diaryDetailResponses = diaries.stream()
-                .map(diary -> DiaryListResponse.DiaryResponse.of(diary.getId(), diary.getTitle()))
-                .toList();
+        return DiaryListResponse.of(getDiaries(category, null));
+    }
 
-        return DiaryListResponse.of(diaryDetailResponses);
+    public DiaryListResponse getMyDiaryList(final Category category, final String username, final String password) {
+        User user = findUser(username, password);
+        return DiaryListResponse.of(getDiaries(category, user));
     }
 
     @Transactional
@@ -75,17 +75,17 @@ public class DiaryService {
         diaryRepository.delete(findDiaryWithUser(id, user));
     }
 
-    public Diary findDiaryWithUser(final long id, final User user) {
+    private Diary findDiaryWithUser(final long id, final User user) {
         return diaryRepository.findByIdAndUser(id, user)
                 .orElseThrow(() -> new DiaryException(NOT_EXISTS_DIARY_WITH_ID_AND_USER));
     }
 
-    public Diary findDiary(final long diaryId) {
+    private Diary findDiary(final long diaryId) {
         return diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new DiaryException(NOT_EXISTS_DIARY_WITH_ID));
     }
 
-    public User findUser(final String username, final String password) {
+    private User findUser(final String username, final String password) {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new UserException(NOT_EXISTS_USER));
 
@@ -95,4 +95,17 @@ public class DiaryService {
 
         return user;
     }
+
+    private List<DiaryListResponse.DiaryResponse> getDiaries(final Category category, final User user) {
+        List<Diary> diaries;
+        if (user == null) {
+            diaries = diaryRepository.findTop10ByCategory(category);
+        } else {
+            diaries = diaryRepository.findTop10ByCategoryAndUser(category, user);
+        }
+        return diaries.stream()
+                .map(diary -> DiaryListResponse.DiaryResponse.of(diary.getId(), diary.getTitle()))
+                .toList();
+    }
+
 }

--- a/src/main/java/org/sopt/seminar2/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/seminar2/diary/service/DiaryService.java
@@ -35,7 +35,7 @@ public class DiaryService {
             final String password
     ) {
         User user = findUser(username, password);
-        Diary diary = Diary.create(user, title, content);
+        Diary diary = Diary.create(user, title, content, category);
         diaryRepository.save(diary);
     }
 
@@ -50,8 +50,8 @@ public class DiaryService {
         );
     }
 
-    public DiaryListResponse getDiaryList() {
-        List<Diary> diaries = diaryRepository.findAllByOrderByCreatedAtDesc();
+    public DiaryListResponse getDiaryList(final Category category) {
+        List<Diary> diaries = diaryRepository.findTop10ByCategory(category);
         List<DiaryListResponse.DiaryResponse> diaryDetailResponses = diaries.stream()
                 .map(diary -> DiaryListResponse.DiaryResponse.of(diary.getId(), diary.getTitle()))
                 .toList();

--- a/src/main/java/org/sopt/seminar2/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/seminar2/diary/service/DiaryService.java
@@ -1,19 +1,16 @@
 package org.sopt.seminar2.diary.service;
 
-import jakarta.persistence.EntityNotFoundException;
-
-import org.sopt.seminar2.diary.api.dto.request.DiaryCreateRequest;
-import org.sopt.seminar2.diary.api.dto.request.DiaryUpdateRequest;
 import org.sopt.seminar2.diary.api.dto.response.DiaryDetailResponse;
 import org.sopt.seminar2.diary.api.dto.response.DiaryListResponse;
-import org.sopt.seminar2.diary.common.code.FailureCode;
 import org.sopt.seminar2.diary.common.exception.DiaryException;
 import org.sopt.seminar2.diary.common.exception.UserException;
+import org.sopt.seminar2.diary.domain.enums.Category;
 import org.sopt.seminar2.diary.domain.repository.DiaryRepository;
+import org.sopt.seminar2.diary.domain.repository.UserRepository;
+
 import org.sopt.seminar2.diary.domain.Diary;
 import org.sopt.seminar2.diary.domain.User;
 
-import org.sopt.seminar2.diary.domain.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,12 +27,17 @@ public class DiaryService {
     private final DiaryRepository diaryRepository;
     private final UserRepository userRepository;
 
-    public void postDiary(final DiaryCreateRequest diaryCreateRequest, final String username, final String password) {
+    public void postDiary(
+            final String title,
+            final String content,
+            final Category category,
+            final String username,
+            final String password
+    ) {
         User user = findUser(username, password);
-        Diary diary = Diary.create(user, diaryCreateRequest.title(), diaryCreateRequest.content());
+        Diary diary = Diary.create(user, title, content);
         diaryRepository.save(diary);
     }
-
 
     public DiaryDetailResponse getDiary(final long id) {
         Diary diary = findDiary(id);
@@ -60,12 +62,12 @@ public class DiaryService {
     @Transactional
     public void updateDiary(
             final long id,
-            final DiaryUpdateRequest diaryUpdateRequest,
+            final String content,
             final String username,
             final String password
     ) {
         User user = findUser(username, password);
-        findDiaryWithUser(id, user).updateDiary(diaryUpdateRequest.content());
+        findDiaryWithUser(id, user).updateDiary(content);
     }
 
     public void deleteDiary(final long id, final String username, final String password) {

--- a/src/main/java/org/sopt/seminar2/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/seminar2/diary/service/DiaryService.java
@@ -78,8 +78,8 @@ public class DiaryService {
                 .orElseThrow(() -> new DiaryException(NOT_EXISTS_DIARY_WITH_ID_AND_USER));
     }
 
-    public Diary findDiary(final long id) {
-        return diaryRepository.findById(id)
+    public Diary findDiary(final long diaryId) {
+        return diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new DiaryException(NOT_EXISTS_DIARY_WITH_ID));
     }
 


### PR DESCRIPTION
# 💗 Work Description
- 우선 로그인/회원가입 API는 따로 구현하지 않았고,, DB에 임시 유저를 생성해서 작업했습니다..ㅎㅎ
- 모든 요구사항을 반영하지는 못했습니다..(ex. 목록조회시 정렬기준, 공개하기 기능)

# 🔆 구현 과정

### - `메인 홈`([794d204](https://github.com/AND-SOPT-SERVER/jungyoon.shin/pull/4/commits/794d204e653bb9bd01e861019b74901c0c1c26c5))

- `request parameter`를 통해 전달받은 `Category`에 대한 유효성 검증은 `Controller`단에서 진행했습니다. `String`값으로 전달 받은 `category` 값을 `enum` 타입의 객체로 변환함과 동시에 정의된 카테고리 값들 중에 해당하지 않는 경우에는 예외를 던집니다. 

https://github.com/AND-SOPT-SERVER/jungyoon.shin/blob/7973e974fc5ca6c8e2ee34de95d9145e2d19a95c/src/main/java/org/sopt/seminar2/diary/domain/enums/Category.java#L20-L26

<br/>

### - `내 일기 모아보기`([7973e97](https://github.com/AND-SOPT-SERVER/jungyoon.shin/pull/4/commits/7973e974fc5ca6c8e2ee34de95d9145e2d19a95c))
- 저의 경우 유저를 식별하기 위해, `request header`에 `usename`과 `password`를 받아 `'인증'` 및 `'인가'` 처리를 하도록 구현했습니다!
- 해당 인증 및 인가 처리를 위해 유저 정보를 받는 API가 다수 있어서 헤더 키 값을 `PASSWORD_HEADER` 처럼 상수 처리 했습니다!
https://github.com/AND-SOPT-SERVER/jungyoon.shin/blob/7973e974fc5ca6c8e2ee34de95d9145e2d19a95c/src/main/java/org/sopt/seminar2/diary/api/controller/DiaryController.java#L77-L86

</br>

### - `interceptor를 통한 유저 인가 기능 구현`([3e2c210](https://github.com/AND-SOPT-SERVER/jungyoon.shin/pull/4/commits/3e2c210f93e4ad93ef58d40c92ede118e0e960a6))
- 우선 일기 수정, 삭제 기능의 경우 해당 일기를 작성한 유저만 삭제 및 수정 권한을 가져야 한다고 판단했습니다!
- 해당 인가 처리를 어디서 할지 고민을 했는데요.. 고민한 방안은 다음과 같이 2가지였습니다!
   > 1. Controller단에서 Validator 클래스를 호출하여 인가 과정 처리

   > 2. interceptor를 구현하여 컨트롤러의 메서드에 도달하기전 인가 과정 처리

- 제가 선택한 방법은 후자이며, 이유는 모든 컨트롤러 마다 1번과 같은 로직을 추가하기 보다는` interceptor`를 통해 전역적인 인가처리를  하는 것이 좋을 것 같다고 판단하였습니다.
<br/>

**👉 1. 커스텀 어노테이션 생성**
- `@Target` : 어노테이션이 사용될 위치를 지정합니다. (저는 메서드에 붙여서 사용할 거여서 다음과 같이 지정했습니다.)
- `@Rentation`: 어노테이션이 유지되는 기간을 지정합니다.
https://github.com/AND-SOPT-SERVER/jungyoon.shin/blob/7973e974fc5ca6c8e2ee34de95d9145e2d19a95c/src/main/java/org/sopt/seminar2/diary/api/annotation/CheckUserAuth.java#L9-L12

<br/>

**👉 2. `HandlerIntercepto`r 인터페이스 구현**
- `handler`가 메서드인 경우 그리고 위에서 만든 어노테이션이 적용된 메서드일 경우에만 인가 로직을 거치게 됩니다.
https://github.com/AND-SOPT-SERVER/jungyoon.shin/blob/7973e974fc5ca6c8e2ee34de95d9145e2d19a95c/src/main/java/org/sopt/seminar2/diary/api/interceptor/CheckUserAuthInterceptor.java#L28-L78

<br/>

**👉 3. `Webconfig`에 `interceptor`등록**
- interceptor 등록을 위한 Config 파일이며, @Component로 Bean으로 등록된 Interceptor를 가져와 registry에 등록해줍니다. 
https://github.com/AND-SOPT-SERVER/jungyoon.shin/blob/7973e974fc5ca6c8e2ee34de95d9145e2d19a95c/src/main/java/org/sopt/seminar2/diary/global/config/WebConfig.java#L10-L20



# 💬 To Reviewers
- 팟짱님이 말씀해주신 부분 반영해서 `request dto` 객체 자체를 `service`단으로 전달하지 않고 풀어서 파라미터로 전달해보았습니다!
- 커스텀 예외처리에 대해 신경써보았는데, 어떨지 모르겠슴당 ㅎㅎ


# 🔗 Reference
[interceptor를 통한 인가 처리](https://kylo8.tistory.com/entry/Spring-boot-%EC%BB%A4%EC%8A%A4%ED%85%80-%EC%96%B4%EB%85%B8%ED%85%8C%EC%9D%B4%EC%85%98%EC%9D%84-%ED%99%9C%EC%9A%A9%ED%95%9C-JWT-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%82%AC%EC%9A%A9%EC%9E%90-%EC%9D%B8%EC%A6%9D%EA%B3%BC-%EA%B6%8C%ED%95%9C-%EA%B4%80%EB%A6%AC-HandlerInterceptor-%EC%9D%B8%EC%A6%9D-%EB%A1%9C%EC%A7%81-%EA%B5%AC%ED%98%84)